### PR TITLE
Feature/mathlib tests

### DIFF
--- a/src/libraries/MathLib.sol
+++ b/src/libraries/MathLib.sol
@@ -48,7 +48,7 @@ library MathLib {
      * @return uint256 wad value (decimal with 18 digits of precision)
      */
     function wMul(uint256 a, uint256 b) public pure returns (uint256) {
-        return (a * b) + (WAD / 2) / WAD;
+        return ((a * b) + (WAD / 2)) / WAD;
     }
 
     /**
@@ -145,16 +145,22 @@ library MathLib {
         // gamma = deltaY / Y' / 2 * (deltaX / alphaDecay')
         uint256 wGamma =
             wDiv(
-                wMul(
-                    wDiv(_tokenQtyAToAdd, _internalTokenAReserveQty),
-                    _tokenBDecayChange
+                (
+                    wMul(
+                        wDiv(_tokenQtyAToAdd, _internalTokenAReserveQty),
+                        _tokenBDecayChange * WAD
+                    )
                 ),
                 _tokenBDecay
             ) /
                 WAD /
                 2;
+
         liquidityTokenQty =
-            (wDiv(_totalSupplyOfLiquidityTokens, WAD - wGamma) * wGamma) /
+            wDiv(
+                wMul(_totalSupplyOfLiquidityTokens * WAD, wGamma),
+                WAD - wGamma
+            ) /
             WAD;
     }
 

--- a/test/mathLibTest.js
+++ b/test/mathLibTest.js
@@ -1,6 +1,8 @@
 const { expect } = require("chai");
 const { ethers, deployments } = require("hardhat");
 
+const WAD = ethers.BigNumber.from(10).pow(18);
+
 describe("MathLib", () => {
   let mathLib;
 
@@ -11,98 +13,147 @@ describe("MathLib", () => {
     mathLib = new ethers.Contract(MathLib.address, MathLib.abi, accounts[0]);
   });
 
-  it("Should return expected results from WAD Division", async () => {
-    const a = 25;
-    const b = 100;
-    expect(await mathLib.wDiv(a, b)).to.equal(
-      ethers.BigNumber.from(10).pow(18).mul(a).div(b)
-    );
+  describe("wDiv", () => {
+    it("Should return expected results", async () => {
+      const a = 25;
+      const b = 100;
+      expect(await mathLib.wDiv(a, b)).to.equal(WAD.mul(a).div(b));
 
-    const c = 100;
-    const d = 25;
-    expect(await mathLib.wDiv(c, d)).to.equal(
-      ethers.BigNumber.from(10).pow(18).mul(c).div(d)
-    );
+      const c = 100;
+      const d = 25;
+      expect(await mathLib.wDiv(c, d)).to.equal(WAD.mul(c).div(d));
 
-    const e = 0;
-    const f = 2;
-    expect(await mathLib.wDiv(e, f)).to.equal(
-      ethers.BigNumber.from(10).pow(18).mul(e).div(f)
-    );
+      const e = 0;
+      const f = 2;
+      expect(await mathLib.wDiv(e, f)).to.equal(WAD.mul(e).div(f));
+    });
+
+    it("Should revert when dividing by zero", async () => {
+      const a = 25;
+      const b = 0;
+      await expect(mathLib.wDiv(a, b)).to.be.reverted;
+    });
+
+    it("Should round to nearest integer", async () => {
+      const a = 20;
+      const b = 33333;
+      // should round up, we add 1 to simulate
+      expect(await mathLib.wDiv(a, b)).to.equal(
+        ethers.BigNumber.from(10).pow(18).mul(a).div(b).add(1)
+      );
+
+      const c = 1;
+      const d = ethers.BigNumber.from("333333333333333333");
+      // 3.3333 rounds down to 3
+      expect(await mathLib.wDiv(c, d)).to.equal(3);
+
+      const e = 1;
+      const f = ethers.BigNumber.from("600000000000000000");
+      // 1.51 rounds up to 2.
+      expect(await mathLib.wDiv(e, f)).to.equal(2);
+    });
   });
 
-  it("Should return expected results from WAD Multiplication", async () => {
-    const a = 25;
-    const b = 100;
-    const wadAB = ethers.BigNumber.from(10).pow(18).mul(a).div(b);
-    const c = 3;
-    expect(await mathLib.wMul(wadAB, c)).to.equal(wadAB.mul(c));
+  describe("wMul", () => {
+    it("Should return expected results", async () => {
+      const a = 25;
+      const b = 100;
+      const wadAB = WAD.mul(a).div(b);
+      const c = 333;
+      const d = 10;
+      const wadCD = WAD.mul(c).div(d);
+      expect(await mathLib.wMul(wadAB, wadCD)).to.equal(
+        wadAB.mul(wadCD).div(WAD)
+      );
+    });
+
+    it("Should return expected results when zero", async () => {
+      const a = 25;
+      const b = 100;
+      const wadAB = WAD.mul(a).div(b);
+      expect(await mathLib.wMul(wadAB, 0)).to.equal(wadAB.mul(0).div(WAD));
+    });
+
+    it("Should round to nearest integer", async () => {
+      const a = 1;
+      const b = 3;
+      const wadAB = WAD.mul(a).div(b);
+      const c = 9;
+      const d = 10;
+      const wadCD = WAD.mul(c).div(d);
+      // we add 1 to simulate the roundup here that occurs.
+      expect(await mathLib.wMul(wadAB, wadCD)).to.equal(
+        wadAB.mul(wadCD).div(WAD).add(1)
+      );
+    });
   });
 
-  it("Should return expected results from WAD Multiplication when zero", async () => {
-    const a = 0;
-    const b = 100;
-    const wadAB = ethers.BigNumber.from(10).pow(18).mul(a).div(b);
-    const c = 3;
-    expect(await mathLib.wMul(wadAB, c)).to.equal(wadAB.mul(c));
+  describe("calculateQty", () => {
+    it("Should return the correct calculateQty", async () => {
+      expect(await mathLib.calculateQty(500, 100, 5000)).to.equal(25000);
+      expect(await mathLib.calculateQty(100, 500, 5000)).to.equal(1000);
+    });
+
+    it("Should revert if any value is 0", async () => {
+      await expect(mathLib.calculateQty(0, 100, 500)).to.be.reverted;
+      await expect(mathLib.calculateQty(500, 0, 1000)).to.be.reverted;
+      await expect(mathLib.calculateQty(500, 100, 0)).to.be.reverted;
+    });
   });
 
-  it("Should return the correct calculateQty", async () => {
-    expect(await mathLib.calculateQty(500, 100, 5000)).to.equal(25000);
+  describe("calculateQtyToReturnAfterFees", () => {
+    it("Should return the correct values", async () => {
+      const tokenSwapQty = 50;
+      const feeInBasisPoints = 30;
+      const expectedFeeAmount = (tokenSwapQty * 30) / 10000;
+      const tokenAReserveQtyBeforeTrade = 100;
+      const tokenAReserveQtyAfterTrade =
+        tokenAReserveQtyBeforeTrade + tokenSwapQty - expectedFeeAmount;
+      const tokenBReserveQtyBeforeTrade = 5000;
+      const pricingConstantK =
+        tokenAReserveQtyBeforeTrade * tokenBReserveQtyBeforeTrade;
+
+      const tokenBReserveQtyBeforeTradeAfterTrade =
+        pricingConstantK / tokenAReserveQtyAfterTrade;
+      const tokenBQtyExpected = Math.floor(
+        tokenBReserveQtyBeforeTrade - tokenBReserveQtyBeforeTradeAfterTrade
+      );
+
+      expect(
+        await mathLib.calculateQtyToReturnAfterFees(
+          tokenSwapQty,
+          tokenAReserveQtyBeforeTrade,
+          tokenBReserveQtyBeforeTrade,
+          feeInBasisPoints
+        )
+      ).to.equal(tokenBQtyExpected);
+    });
+
+    it("Should return the correct value when fees are zero", async () => {
+      const tokenSwapQty = 15;
+      const tokenAReserveQtyBeforeTrade = 2000;
+      const tokenAReserveQtyAfterTrade =
+        tokenAReserveQtyBeforeTrade + tokenSwapQty;
+      const tokenBReserveQtyBeforeTrade = 3000;
+      const pricingConstantK =
+        tokenAReserveQtyBeforeTrade * tokenBReserveQtyBeforeTrade;
+
+      const tokenBReserveQtyBeforeTradeAfterTrade =
+        pricingConstantK / tokenAReserveQtyAfterTrade;
+      const tokenBQtyExpected = Math.floor(
+        tokenBReserveQtyBeforeTrade - tokenBReserveQtyBeforeTradeAfterTrade
+      );
+
+      expect(
+        await mathLib.calculateQtyToReturnAfterFees(
+          tokenSwapQty,
+          tokenAReserveQtyBeforeTrade,
+          tokenBReserveQtyBeforeTrade,
+          0
+        )
+      ).to.equal(tokenBQtyExpected);
+    });
   });
-
-  it("Should return the correct calculateQtyToReturnAfterFees", async () => {
-    const tokenSwapQty = 50;
-    const feeInBasisPoints = 30;
-    const expectedFeeAmount = (tokenSwapQty * 30) / 10000;
-    const tokenAReserveQtyBeforeTrade = 100;
-    const tokenAReserveQtyAfterTrade =
-      tokenAReserveQtyBeforeTrade + tokenSwapQty - expectedFeeAmount;
-    const tokenBReserveQtyBeforeTrade = 5000;
-    const pricingConstantK =
-      tokenAReserveQtyBeforeTrade * tokenBReserveQtyBeforeTrade;
-
-    const tokenBReserveQtyBeforeTradeAfterTrade =
-      pricingConstantK / tokenAReserveQtyAfterTrade;
-    const tokenBQtyExpected = Math.floor(
-      tokenBReserveQtyBeforeTrade - tokenBReserveQtyBeforeTradeAfterTrade
-    );
-
-    expect(
-      await mathLib.calculateQtyToReturnAfterFees(
-        tokenSwapQty,
-        tokenAReserveQtyBeforeTrade,
-        tokenBReserveQtyBeforeTrade,
-        feeInBasisPoints
-      )
-    ).to.equal(tokenBQtyExpected);
-  });
-
-  it("Should return the correct calculateQtyToReturnAfterFees when fees are zero", async () => {
-    const tokenSwapQty = 15;
-    const tokenAReserveQtyBeforeTrade = 2000;
-    const tokenAReserveQtyAfterTrade =
-      tokenAReserveQtyBeforeTrade + tokenSwapQty;
-    const tokenBReserveQtyBeforeTrade = 3000;
-    const pricingConstantK =
-      tokenAReserveQtyBeforeTrade * tokenBReserveQtyBeforeTrade;
-
-    const tokenBReserveQtyBeforeTradeAfterTrade =
-      pricingConstantK / tokenAReserveQtyAfterTrade;
-    const tokenBQtyExpected = Math.floor(
-      tokenBReserveQtyBeforeTrade - tokenBReserveQtyBeforeTradeAfterTrade
-    );
-
-    expect(
-      await mathLib.calculateQtyToReturnAfterFees(
-        tokenSwapQty,
-        tokenAReserveQtyBeforeTrade,
-        tokenBReserveQtyBeforeTrade,
-        0
-      )
-    ).to.equal(tokenBQtyExpected);
-  });
-
   describe("calculateLiquidityTokenQtyForDoubleAssetEntry", () => {
     it("Should return the correct qty of liquidity tokens", async () => {
       const totalSupplyOfLiquidityTokens = 50;
@@ -116,6 +167,102 @@ describe("MathLib", () => {
           baseTokenBalance
         )
       ).to.equal(15);
+    });
+  });
+
+  describe("calculateLiquidityTokenQtyForSingleAssetEntry", () => {
+    it("Should return the correct qty of liquidity tokens with a rebase down", async () => {
+      // Scenario: We have 1000:5000 A:B or X:Y, a rebase down occurs (of 50 tokens)
+      // and a user needs to 50 tokens in order to remove the decay
+      const totalSupplyOfLiquidityTokens = 5000;
+      const tokenAQtyToAdd = 50;
+      const tokenAInternalReserveQtyAfterTransaction = 1000; // 950 + 50 brining us back to original state.
+      const tokenBDecayChange = 250;
+      const tokenBDecay = 250;
+
+      const gamma =
+        (tokenAQtyToAdd / tokenAInternalReserveQtyAfterTransaction / 2) *
+        (tokenBDecayChange / tokenBDecay);
+      const expectLiquidityTokens = Math.floor(
+        (totalSupplyOfLiquidityTokens * gamma) / (1 - gamma)
+      );
+      expect(
+        await mathLib.calculateLiquidityTokenQtyForSingleAssetEntry(
+          totalSupplyOfLiquidityTokens,
+          tokenAQtyToAdd,
+          tokenAInternalReserveQtyAfterTransaction,
+          tokenBDecayChange,
+          tokenBDecay
+        )
+      ).to.equal(expectLiquidityTokens);
+
+      // if we supply half, and remove half the decay, we should get roughly 1/2 the tokens
+      const tokenAQtyToAdd2 = 25;
+      const tokenAInternalReserveQtyAfterTransaction2 = 975; // 950 + 25 brining us back to original state.
+      const tokenBDecayChange2 = 125;
+      const gamma2 =
+        (tokenAQtyToAdd2 / tokenAInternalReserveQtyAfterTransaction2 / 2) *
+        (tokenBDecayChange2 / tokenBDecay);
+      const expectLiquidityTokens2 = Math.floor(
+        (totalSupplyOfLiquidityTokens * gamma2) / (1 - gamma2)
+      );
+
+      expect(
+        await mathLib.calculateLiquidityTokenQtyForSingleAssetEntry(
+          totalSupplyOfLiquidityTokens,
+          tokenAQtyToAdd2,
+          tokenAInternalReserveQtyAfterTransaction2,
+          tokenBDecayChange2,
+          tokenBDecay
+        )
+      ).to.equal(expectLiquidityTokens2);
+    });
+
+    it("Should return the correct qty of liquidity tokens with a rebase up", async () => {
+      // Scenario: We have 1000:5000 A:B or X:Y, a rebase up occurs (of 500 tokens)
+      // and a user needs to add 2500 base tokens to remove the quote decay
+      const totalSupplyOfLiquidityTokens = 5000;
+      const tokenAQtyToAdd = 2500;
+      const tokenAInternalReserveQtyAfterTransaction = 7500; // 5000 + 2500 to offset rebase up
+      const tokenBDecayChange = 500;
+      const tokenBDecay = 500;
+
+      const gamma =
+        (tokenAQtyToAdd / tokenAInternalReserveQtyAfterTransaction / 2) *
+        (tokenBDecayChange / tokenBDecay);
+      const expectLiquidityTokens = Math.floor(
+        (totalSupplyOfLiquidityTokens * gamma) / (1 - gamma)
+      );
+      expect(
+        await mathLib.calculateLiquidityTokenQtyForSingleAssetEntry(
+          totalSupplyOfLiquidityTokens,
+          tokenAQtyToAdd,
+          tokenAInternalReserveQtyAfterTransaction,
+          tokenBDecayChange,
+          tokenBDecay
+        )
+      ).to.equal(expectLiquidityTokens);
+
+      // if we supply half, and remove half the decay, we should get roughly 1/2 the tokens
+      const tokenAQtyToAdd2 = 2500;
+      const tokenAInternalReserveQtyAfterTransaction2 = 6250;
+      const tokenBDecayChange2 = 250;
+      const gamma2 =
+        (tokenAQtyToAdd2 / tokenAInternalReserveQtyAfterTransaction2 / 2) *
+        (tokenBDecayChange2 / tokenBDecay);
+      const expectLiquidityTokens2 = Math.floor(
+        (totalSupplyOfLiquidityTokens * gamma2) / (1 - gamma2)
+      );
+
+      expect(
+        await mathLib.calculateLiquidityTokenQtyForSingleAssetEntry(
+          totalSupplyOfLiquidityTokens,
+          tokenAQtyToAdd2,
+          tokenAInternalReserveQtyAfterTransaction2,
+          tokenBDecayChange2,
+          tokenBDecay
+        )
+      ).to.equal(expectLiquidityTokens2);
     });
   });
 


### PR DESCRIPTION
merge and rebase against #37 first

Resolves #17 by adding more unit tests to the MathLib and fixes a bug in wMul.

Without solcover working with hardat it is hard to estimate coverage, so will circle back later once solidity coverage is patched (https://github.com/sc-forks/solidity-coverage/pull/643)