### PR TITLE
adds fees in liquidity tokens minted to a fee address

### DIFF
--- a/deploy/core/exchangeFactory.js
+++ b/deploy/core/exchangeFactory.js
@@ -1,13 +1,13 @@
 module.exports = async ({ getNamedAccounts, deployments }) => {
   const { deploy, log } = deployments;
   const namedAccounts = await getNamedAccounts();
-  const { admin } = namedAccounts;
+  const { admin, feeRecipient } = namedAccounts;
 
   const mathLib = await deployments.get("MathLib");
   const deployResult = await deploy("ExchangeFactory", {
     from: admin,
     contract: "ExchangeFactory",
-    args: [],
+    args: [feeRecipient],
     libraries: {
       MathLib: mathLib.address,
     },

--- a/deploy/test/baseToken.js
+++ b/deploy/test/baseToken.js
@@ -2,7 +2,7 @@ module.exports = async ({ getNamedAccounts, deployments }) => {
   const { deploy, log } = deployments;
   const namedAccounts = await getNamedAccounts();
   const { admin } = namedAccounts;
-  const initialSupply = 1000000000;
+  const initialSupply = 1000000000000;
   const deployResult = await deploy("BaseToken", {
     from: admin,
     contract: "ERC20PresetFixedSupply",

--- a/deploy/test/exchange.js
+++ b/deploy/test/exchange.js
@@ -6,12 +6,19 @@ module.exports = async ({ getNamedAccounts, deployments }) => {
   const baseToken = await deployments.get("BaseToken");
   const quoteToken = await deployments.get("QuoteToken");
   const mathLib = await deployments.get("MathLib");
+  const exchangeFactory = await deployments.get("ExchangeFactory");
   const name = "EGT LP Token";
   const symbol = "EGTLPS";
   const deployResult = await deploy("EGT Exchange", {
     from: admin,
     contract: "Exchange",
-    args: [name, symbol, quoteToken.address, baseToken.address],
+    args: [
+      name,
+      symbol,
+      quoteToken.address,
+      baseToken.address,
+      exchangeFactory.address,
+    ],
     libraries: {
       MathLib: mathLib.address,
     },
@@ -23,4 +30,9 @@ module.exports = async ({ getNamedAccounts, deployments }) => {
   }
 };
 module.exports.tags = ["EGT Exchange"];
-module.exports.dependencies = ["QuoteToken", "BaseToken", "MathLib"];
+module.exports.dependencies = [
+  "QuoteToken",
+  "BaseToken",
+  "MathLib",
+  "ExchangeFactory",
+];

--- a/deploy/test/quoteToken.js
+++ b/deploy/test/quoteToken.js
@@ -2,7 +2,7 @@ module.exports = async ({ getNamedAccounts, deployments }) => {
   const { deploy, log } = deployments;
   const namedAccounts = await getNamedAccounts();
   const { admin } = namedAccounts;
-  const initialSupply = 1000000000;
+  const initialSupply = 1000000000000;
   const deployResult = await deploy("QuoteToken", {
     from: admin,
     contract: "ElasticMock",

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -40,6 +40,9 @@ module.exports = {
     trader2: {
       default: 4,
     },
+    feeRecipient: {
+      default: 5,
+    },
   },
   contractSizer: {
     alphaSort: true,

--- a/src/interfaces/IExchangeFactory.sol
+++ b/src/interfaces/IExchangeFactory.sol
@@ -1,0 +1,6 @@
+//SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.4;
+
+interface IExchangeFactory {
+    function feeAddress() external view returns (address);
+}


### PR DESCRIPTION
#### Background
On all add or remove liquidity events, we now check and if needed mint Liquidity tokens to a fee address (the DAO).  Sushi-swap mints fees to their staked token holders using liquidity tokens in a similar fashion.  Currently, the fee address can be changed, but the amount of fees can not be (again similar to other protocols), we can add this as a feature in the future if we think we need to before launch.

#### Big Changes to note alongside the fee functionality
- removes all but Add / Remove Liquidity to avoid contract size from becoming too large for mainnet and simplifying testing and maintainability. 
- Modifies the initial Ro calculation to match uni v2


Resolves #28 